### PR TITLE
Add ability to include precompiled objects and libraries in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ include_directories(
 
 add_definitions(-DF_CPU=16000000)
 
-add_avr_libraries("${PROJECT_NAME} "atmega2560" 
+add_avr_libraries(${PROJECT_NAME} "atmega2560" 
     ${CMAKE_SOURCE_DIR}/bin/lib.a
     ${CMAKE_SOURCE_DIR}/bin/obj.o
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CMake AVR Toolchain
 
-A toolchain file for working with `avr-gcc`.
+A toolchain file for working with `avr-gcc`. Modified from the original branch to add support for precompiled objects and libraries
 
 Usage
 -----
@@ -13,7 +13,7 @@ Copy `avr-gcc.toolchain.cmake` into your project (or you could use this repo as 
 
 The following is an example `CMakeLists.txt` for an `atmega2560` project (Arduino Mega).
 
-```
+```cmake
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_TOOLCHAIN_FILE "/path/to/avr-gcc.toolchain.cmake")
@@ -25,7 +25,8 @@ include_directories(
 )
 
 add_definitions(-DF_CPU=16000000)
-add_avr_executable(${PROJECT_NAME} "atmega2560"
+
+add_avr_executable(${PROJECT_NAME} "atmega2560" ""
     src/main.cpp
 )
 ```
@@ -40,4 +41,17 @@ cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/avr-gcc.toolchain.cmake
 
 ```bash
 avrdude -v -patmega2560 -cwiring -PCOM6 -b115200 -D -Uflash:w:myproject-atmega2560.hex
+```
+
+## Libraries
+
+Optional libraries and precompiled objects can be included through the use of an array type containing absolute paths pointing to the library files
+
+```cmake
+...
+
+set(libraries ${CMAKE_SOURCE_DIR}/lib/library.a ${CMAKE_SOURCE_DIR}/bin/object.o)
+add_avr_executable(${PROJECT_NAME} "atmega2560" ${libraries}
+    src/main.cpp
+)
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CMake AVR Toolchain
 
-A toolchain file for working with `avr-gcc`. Modified from the original branch to add support for precompiled objects and libraries.
+A toolchain file for working with `avr-gcc`.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CMake AVR Toolchain
 
-A toolchain file for working with `avr-gcc`. Modified from the original branch to add support for precompiled objects and libraries
+A toolchain file for working with `avr-gcc`. Modified from the original branch to add support for precompiled objects and libraries.
 
 Usage
 -----
@@ -26,7 +26,12 @@ include_directories(
 
 add_definitions(-DF_CPU=16000000)
 
-add_avr_executable(${PROJECT_NAME} "atmega2560" ""
+add_avr_executable("${PROJECT_NAME} "atmega2560" 
+    ${CMAKE_SOURCE_DIR}/bin/lib.a
+    ${CMAKE_SOURCE_DIR}/bin/obj.o
+)
+
+add_avr_executable(${PROJECT_NAME} "atmega2560"
     src/main.cpp
 )
 ```
@@ -45,13 +50,13 @@ avrdude -v -patmega2560 -cwiring -PCOM6 -b115200 -D -Uflash:w:myproject-atmega25
 
 ## Libraries
 
-Optional libraries and precompiled objects can be included through the use of an array type containing absolute paths pointing to the library files
+Optional libraries and precompiled objects can be included through the `add_avr_libraries` macro, which is similar to the `add_avr_executable` macro
 
 ```cmake
 ...
 
-set(libraries ${CMAKE_SOURCE_DIR}/lib/library.a ${CMAKE_SOURCE_DIR}/bin/object.o)
-add_avr_executable(${PROJECT_NAME} "atmega2560" ${libraries}
-    src/main.cpp
+add_avr_libraries("${PROJECT_NAME} "atmega2560" 
+    ${CMAKE_SOURCE_DIR}/bin/lib.a
+    ${CMAKE_SOURCE_DIR}/bin/obj.o
 )
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ include_directories(
 
 add_definitions(-DF_CPU=16000000)
 
-add_avr_executable("${PROJECT_NAME} "atmega2560" 
+add_avr_libraries("${PROJECT_NAME} "atmega2560" 
     ${CMAKE_SOURCE_DIR}/bin/lib.a
     ${CMAKE_SOURCE_DIR}/bin/obj.o
 )

--- a/avr-gcc.toolchain.cmake
+++ b/avr-gcc.toolchain.cmake
@@ -77,7 +77,14 @@ find_program(AVR_UPLOAD
 
 set(AVR_LINKER_LIBS "-lc -lm -lgcc -Wl,-lprintf_flt -Wl,-u,vfprintf")
 
-macro(add_avr_executable target_name avr_mcu libraries)
+macro(add_avr_libraries target_name avr_mcu)
+    target_link_libraries(
+        ${target_name}-${avr_mcu}.elf
+        ${ARGN}
+    )
+endmacro()
+
+macro(add_avr_executable target_name avr_mcu)
 
     set(elf_file ${target_name}-${avr_mcu}.elf)
     set(map_file ${target_name}-${avr_mcu}.map)
@@ -88,13 +95,6 @@ macro(add_avr_executable target_name avr_mcu libraries)
     add_executable(${elf_file}
         ${ARGN}
     )
-
-    if (NOT ${libraries} STREQUAL "")
-        target_link_libraries(${elf_file}
-            ${libraries}
-        )
-        message("Libraries detected")
-    endif()
 
     set_target_properties(
         ${elf_file}

--- a/avr-gcc.toolchain.cmake
+++ b/avr-gcc.toolchain.cmake
@@ -77,6 +77,7 @@ find_program(AVR_UPLOAD
 
 set(AVR_LINKER_LIBS "-lc -lm -lgcc -Wl,-lprintf_flt -Wl,-u,vfprintf")
 
+# Macro for adding precompiled libraries
 macro(add_avr_libraries target_name avr_mcu)
     target_link_libraries(
         ${target_name}-${avr_mcu}.elf

--- a/avr-gcc.toolchain.cmake
+++ b/avr-gcc.toolchain.cmake
@@ -89,9 +89,12 @@ macro(add_avr_executable target_name avr_mcu libraries)
         ${ARGN}
     )
 
-    target_link_libraries(${elf_file}
-        ${libraries}
-    )
+    if (NOT ${libraries} STREQUAL "")
+        target_link_libraries(${elf_file}
+            ${libraries}
+        )
+        message("Libraries detected")
+    endif()
 
     set_target_properties(
         ${elf_file}

--- a/avr-gcc.toolchain.cmake
+++ b/avr-gcc.toolchain.cmake
@@ -77,7 +77,7 @@ find_program(AVR_UPLOAD
 
 set(AVR_LINKER_LIBS "-lc -lm -lgcc -Wl,-lprintf_flt -Wl,-u,vfprintf")
 
-macro(add_avr_executable target_name avr_mcu)
+macro(add_avr_executable target_name avr_mcu libraries)
 
     set(elf_file ${target_name}-${avr_mcu}.elf)
     set(map_file ${target_name}-${avr_mcu}.map)
@@ -87,6 +87,10 @@ macro(add_avr_executable target_name avr_mcu)
     # create elf file
     add_executable(${elf_file}
         ${ARGN}
+    )
+
+    target_link_libraries(${elf_file}
+        ${libraries}
     )
 
     set_target_properties(


### PR DESCRIPTION
Adds the macro `add_avr_libraries` which allows multiple precompiled objects of any type and links them to the executable specified as the first argument. The `README.md` file has been appropriately updated to document the changes.